### PR TITLE
chrome-test: 初期セットアップ + ログイン状態保存チェックボックス追加

### DIFF
--- a/chrome-test/.gitignore
+++ b/chrome-test/.gitignore
@@ -1,0 +1,5 @@
+# Playwright MCP の実行アーティファクト
+.playwright-mcp/
+
+# 動作確認時のスクリーンショット
+*.png

--- a/chrome-test/README.md
+++ b/chrome-test/README.md
@@ -1,0 +1,58 @@
+# chrome-test: Claude Code × Chrome Extension 連携テスト
+
+Claude Code (CLI) から Chrome Extension 経由でブラウザを操作し、UI検証を自律的に行えるかを試す最小実験。
+
+## ファイル
+
+- `index.html` — バグを意図的に仕込んだログインフォーム
+- `serve.sh` — 開発サーバー起動（python3 http.server）
+- `tmux-start.sh` — tmuxで2ペイン（dev server + claude --chrome）を一発起動
+
+## 仕込んだバグ（Claude Codeが発見すべきもの）
+
+ネタバレ注意。Claude Codeに先に発見させたい場合はここを読まずに試行。
+
+<details>
+<summary>クリックで展開</summary>
+
+1. **メールバリデーション反転** — `@` を含まないと「正しいメールを入れて」と弾かれ、含むと通る
+2. **パスワード長チェック未実装** — 8文字未満でも通過してしまう（コメントだけ残してロジックなし）
+3. **submitでページリロード** — `event.preventDefault()` 忘れにより、フォーム送信時にページが再読込される
+
+</details>
+
+## 試し方
+
+### 推奨: tmuxで一発起動
+
+```bash
+~/playground/chrome-test/tmux-start.sh
+```
+
+左ペインに開発サーバー、右ペインに `claude --chrome` が起動した状態で attach する。
+既にセッションがあればそのまま attach（重複起動しない）。
+
+### 手動: ターミナル2枚を別々に開く場合
+
+ターミナル A — 開発サーバー起動:
+```bash
+cd ~/playground/chrome-test
+./serve.sh
+```
+
+ターミナル B — Claude Code を Chrome連携で起動:
+```bash
+cd ~/playground/chrome-test
+claude --chrome
+```
+
+### Claudeに以下を依頼
+
+```
+http://localhost:8000 を開いて、ログインフォームのバリデーションをテストしてください。
+複数の入力パターン（正常/異常/境界値）を試して、想定どおりに動かない箇所をすべて報告してください。
+```
+
+### 期待される結果
+
+Claude が自分でブラウザを操作し、3つのバグをすべて検出して報告する。

--- a/chrome-test/index.html
+++ b/chrome-test/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>Chrome Extension テスト用 ログインフォーム</title>
+<style>
+  body { font-family: -apple-system, sans-serif; max-width: 400px; margin: 60px auto; padding: 20px; }
+  h1 { font-size: 20px; }
+  label { display: block; margin-top: 16px; font-weight: bold; }
+  input { width: 100%; padding: 8px; margin-top: 4px; box-sizing: border-box; }
+  button { margin-top: 20px; padding: 10px 20px; font-size: 16px; cursor: pointer; }
+  .error { color: #c00; margin-top: 8px; min-height: 20px; }
+  .success { color: #060; margin-top: 16px; }
+  .checkbox-row { display: block; margin-top: 16px; font-weight: normal; }
+  .checkbox-row input { width: auto; margin: 0 6px 0 0; padding: 0; vertical-align: middle; }
+</style>
+</head>
+<body>
+<h1>ログイン</h1>
+<form id="loginForm">
+  <label>メールアドレス
+    <input type="text" id="email" placeholder="user@example.com">
+  </label>
+  <div class="error" id="emailError"></div>
+
+  <label>パスワード
+    <input type="password" id="password" placeholder="8文字以上">
+  </label>
+  <div class="error" id="passwordError"></div>
+
+  <label class="checkbox-row">
+    <input type="checkbox" id="rememberMe">
+    ログイン状態を保存する
+  </label>
+
+  <button type="submit">ログイン</button>
+  <div class="success" id="successMessage"></div>
+</form>
+
+<script>
+  const form = document.getElementById('loginForm');
+
+  form.addEventListener('submit', function(e) {
+    const email = document.getElementById('email').value;
+    const password = document.getElementById('password').value;
+    const emailError = document.getElementById('emailError');
+    const passwordError = document.getElementById('passwordError');
+    const successMessage = document.getElementById('successMessage');
+
+    emailError.textContent = '';
+    passwordError.textContent = '';
+    successMessage.textContent = '';
+
+    let valid = true;
+
+    if (email.includes('@')) {
+      emailError.textContent = '正しいメールアドレスを入力してください';
+      valid = false;
+    }
+
+    if (password.length > 0 && password.length < 100) {
+      // パスワード長チェックロジック未実装
+    }
+
+    if (valid) {
+      successMessage.textContent = 'ログインに成功しました';
+    }
+  });
+</script>
+</body>
+</html>

--- a/chrome-test/serve.sh
+++ b/chrome-test/serve.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+echo "Serving at http://localhost:8000  (Ctrl+C to stop)"
+python3 -m http.server 8000

--- a/chrome-test/tmux-start.sh
+++ b/chrome-test/tmux-start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+SESSION="chrome-test"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+  echo "Existing '$SESSION' session found. Attaching..."
+  tmux attach -t "$SESSION"
+  exit 0
+fi
+
+# 新セッション(detached)作成 + 左ペインIDを取得
+tmux new-session -d -s "$SESSION" -c "$DIR" -n "main"
+SERVE_PANE=$(tmux display-message -p -t "$SESSION:main" '#{pane_id}')
+
+# 右ペインを分割で作成 + IDを取得（-P -Fで返す）
+CLAUDE_PANE=$(tmux split-window -h -t "$SERVE_PANE" -c "$DIR" -P -F '#{pane_id}')
+
+# 各ペインにIDで明示指定してコマンド送信
+tmux send-keys -t "$SERVE_PANE" "./serve.sh" C-m
+tmux send-keys -t "$CLAUDE_PANE" "claude --chrome" C-m
+
+# 右ペインにフォーカスしてattach
+tmux select-pane -t "$CLAUDE_PANE"
+tmux attach -t "$SESSION"


### PR DESCRIPTION
## Summary
- Claude Code × Chrome Extension 連携テスト用のログインフォーム実験を新規追加
- 意図的なバリデーションバグ3種を仕込んだ `index.html`、開発サーバー/tmux 起動スクリプト、README、実行アーティファクト除外用 `.gitignore` を同梱
- 「ログイン状態を保存する」チェックボックスをフォームに追加し、Playwright MCP でレンダリング・トグル動作確認済み

## Test plan
- [ ] `chrome-test/serve.sh` でローカルサーバーが起動すること
- [ ] ブラウザで `index.html` を開いてログインフォームが表示されること
- [ ] 「ログイン状態を保存する」チェックボックスのトグルが動作すること